### PR TITLE
Add collapsible totals sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         <summary>Situación Global</summary>
         <div class="totals-content static-content">
           <p>Administración: 45 propios + 60 comunes = 105</p>
-          <p>Contabilidad: 50 propios + 60 comunes = 110</p>
+          <p>Contabilidad: 50 propios + 57 comunes = 107</p>
           <p>Créditos Comunes: 60</p>
           <p>Total Doble Titulación: 155</p>
           <p>Ahorro por doble titulación: 57 créditos</p>

--- a/index.html
+++ b/index.html
@@ -25,12 +25,28 @@
       <p class="program-raw">Administración: <span id="admin-total-raw">0</span> créditos | Contabilidad: <span id="cont-total-raw">0</span> créditos</p>
     </div>
 
-    <div class="global-totals">
-      <p>Administración visible: <span id="admin-propios">0</span> propios + <span id="admin-comunes">0</span> comunes = <span id="admin-total">0</span></p>
-      <p>Contabilidad visible: <span id="cont-propios">0</span> propios + <span id="cont-comunes">0</span> comunes = <span id="cont-total">0</span></p>
-      <p>Créditos Comunes: <span id="total-comunes">0</span></p>
-      <p>Total Doble Titulación: <span id="total-global">0</span></p>
-      <p>Ahorro por doble titulación: <span id="total-ahorro">0</span> créditos</p>
+    <div class="totals-container">
+      <details class="totals-box" id="static-box" open>
+        <summary>Situación Global</summary>
+        <div class="totals-content static-content">
+          <p>Administración: 45 propios + 60 comunes = 105</p>
+          <p>Contabilidad: 50 propios + 60 comunes = 110</p>
+          <p>Créditos Comunes: 60</p>
+          <p>Total Doble Titulación: 155</p>
+          <p>Ahorro por doble titulación: 57 créditos</p>
+        </div>
+      </details>
+
+      <details class="totals-box" id="dynamic-box" open>
+        <summary>Tus Cálculos</summary>
+        <div class="totals-content global-totals">
+          <p>Administración: <span id="admin-propios">0</span> propios + <span id="admin-comunes">0</span> comunes = <span id="admin-total">0</span></p>
+          <p>Contabilidad: <span id="cont-propios">0</span> propios + <span id="cont-comunes">0</span> comunes = <span id="cont-total">0</span></p>
+          <p>Créditos Comunes: <span id="total-comunes">0</span></p>
+          <p>Total Doble Titulación: <span id="total-global">0</span></p>
+          <p>Ahorro por doble titulación: <span id="total-ahorro">0</span> créditos</p>
+        </div>
+      </details>
     </div>
   
     <div class="grid-container">

--- a/script.js
+++ b/script.js
@@ -181,11 +181,13 @@ async function cargarMaterias() {
 
 function updateTotals() {
   const totals = {};
+  for (const sem in semesterTotalsEls) {
+    totals[sem] = { admin: 0, contabilidad: 0, comunes: 0 };
+  }
   const global = {admin:0, contabilidad:0, comunes:0};
   document.querySelectorAll('.subject-card').forEach(card => {
     if (card.dataset.homologada === 'true') return;
     const sem = card.dataset.semester;
-    if (!totals[sem]) totals[sem] = {admin:0, contabilidad:0, comunes:0};
     const prog = card.dataset.program;
     const cred = Number(card.dataset.creditos);
     totals[sem][prog] += cred;

--- a/script.js
+++ b/script.js
@@ -14,6 +14,8 @@ function toRoman(num) {
 const semesterTotalsEls = {}; // {semester: {header, admin, contabilidad, comunes}}
 let adminRawTotal = 0;
 let contRawTotal = 0;
+let adminByName = {};
+let contByName = {};
 
 function createSemesterHeader(num) {
   const header = document.createElement('div');
@@ -86,8 +88,8 @@ async function cargarMaterias() {
     const adminFiltered = {};
     const contFiltered = {};
 
-    const adminByName = {};
-    const contByName = {};
+    adminByName = {};
+    contByName = {};
     adminRawTotal = 0;
     contRawTotal = 0;
 
@@ -181,15 +183,40 @@ async function cargarMaterias() {
 
 function updateTotals() {
   const totals = {};
-  const global = {admin:0, contabilidad:0, comunes:0};
+  Object.keys(semesterTotalsEls).forEach(sem => {
+    totals[sem] = {admin: 0, contabilidad: 0, comunes: 0};
+  });
+
+  let adminPropios = 0;
+  let adminComunes = 0;
+  let contPropios = 0;
+  let contComunes = 0;
+  let comunesUnion = 0;
+
   document.querySelectorAll('.subject-card').forEach(card => {
-    if (card.dataset.homologada === 'true') return;
+    const name = card.dataset.nombre;
     const sem = card.dataset.semester;
-    if (!totals[sem]) totals[sem] = {admin:0, contabilidad:0, comunes:0};
-    const prog = card.dataset.program;
-    const cred = Number(card.dataset.creditos);
-    totals[sem][prog] += cred;
-    global[prog] += cred;
+    if (card.dataset.homologada === 'true') return;
+
+    if (card.dataset.program === 'admin') {
+      const cred = Number(card.dataset.creditos);
+      adminPropios += cred;
+      totals[sem].admin += cred;
+    } else if (card.dataset.program === 'contabilidad') {
+      const cred = Number(card.dataset.creditos);
+      contPropios += cred;
+      totals[sem].contabilidad += cred;
+    } else if (card.dataset.program === 'comunes') {
+      const adminCred = adminByName[name] ? Number(adminByName[name].credits) : 0;
+      const contCred = contByName[name] ? Number(contByName[name].credits) : 0;
+      const unionCred = Number(card.dataset.creditos);
+      adminComunes += adminCred;
+      contComunes += contCred;
+      comunesUnion += unionCred;
+      totals[sem].admin += adminCred;
+      totals[sem].contabilidad += contCred;
+      totals[sem].comunes += unionCred;
+    }
   });
 
   for (const sem in totals) {
@@ -203,22 +230,23 @@ function updateTotals() {
     }
   }
 
-  const adminTotal = global.admin + global.comunes;
-  const contTotal = global.contabilidad + global.comunes;
-  const globalTotal = global.admin + global.contabilidad + global.comunes;
+  const adminTotal = adminPropios + adminComunes;
+  const contTotal = contPropios + contComunes;
+  const globalTotal = adminPropios + contPropios + comunesUnion;
   const ahorro = adminRawTotal + contRawTotal - globalTotal;
+
   document.getElementById('admin-total-raw').textContent = adminRawTotal;
   document.getElementById('cont-total-raw').textContent = contRawTotal;
 
-  document.getElementById('admin-propios').textContent = global.admin;
-  document.getElementById('admin-comunes').textContent = global.comunes;
+  document.getElementById('admin-propios').textContent = adminPropios;
+  document.getElementById('admin-comunes').textContent = adminComunes;
   document.getElementById('admin-total').textContent = adminTotal;
 
-  document.getElementById('cont-propios').textContent = global.contabilidad;
-  document.getElementById('cont-comunes').textContent = global.comunes;
+  document.getElementById('cont-propios').textContent = contPropios;
+  document.getElementById('cont-comunes').textContent = contComunes;
   document.getElementById('cont-total').textContent = contTotal;
 
-  document.getElementById('total-comunes').textContent = global.comunes;
+  document.getElementById('total-comunes').textContent = comunesUnion;
   document.getElementById('total-global').textContent = globalTotal;
   document.getElementById('total-ahorro').textContent = ahorro;
 }

--- a/script.js
+++ b/script.js
@@ -192,15 +192,13 @@ function updateTotals() {
     global[prog] += cred;
   });
 
-  for (const sem in totals) {
-    const t = totals[sem];
+  for (const sem in semesterTotalsEls) {
+    const t = totals[sem] || {admin: 0, contabilidad: 0, comunes: 0};
     const totalSem = t.admin + t.contabilidad + t.comunes;
-    if (semesterTotalsEls[sem]) {
-      semesterTotalsEls[sem].admin.textContent = `Total: ${t.admin}`;
-      semesterTotalsEls[sem].contabilidad.textContent = `Total: ${t.contabilidad}`;
-      semesterTotalsEls[sem].comunes.textContent = `Total: ${t.comunes}`;
-      semesterTotalsEls[sem].header.textContent = `Semestre ${toRoman(Number(sem))}: ${totalSem} créditos`;
-    }
+    semesterTotalsEls[sem].admin.textContent = `Total: ${t.admin}`;
+    semesterTotalsEls[sem].contabilidad.textContent = `Total: ${t.contabilidad}`;
+    semesterTotalsEls[sem].comunes.textContent = `Total: ${t.comunes}`;
+    semesterTotalsEls[sem].header.textContent = `Semestre ${toRoman(Number(sem))}: ${totalSem} créditos`;
   }
 
   const adminTotal = global.admin + global.comunes;

--- a/script.js
+++ b/script.js
@@ -14,8 +14,6 @@ function toRoman(num) {
 const semesterTotalsEls = {}; // {semester: {header, admin, contabilidad, comunes}}
 let adminRawTotal = 0;
 let contRawTotal = 0;
-let adminByName = {};
-let contByName = {};
 
 function createSemesterHeader(num) {
   const header = document.createElement('div');
@@ -88,8 +86,8 @@ async function cargarMaterias() {
     const adminFiltered = {};
     const contFiltered = {};
 
-    adminByName = {};
-    contByName = {};
+    const adminByName = {};
+    const contByName = {};
     adminRawTotal = 0;
     contRawTotal = 0;
 
@@ -183,40 +181,15 @@ async function cargarMaterias() {
 
 function updateTotals() {
   const totals = {};
-  Object.keys(semesterTotalsEls).forEach(sem => {
-    totals[sem] = {admin: 0, contabilidad: 0, comunes: 0};
-  });
-
-  let adminPropios = 0;
-  let adminComunes = 0;
-  let contPropios = 0;
-  let contComunes = 0;
-  let comunesUnion = 0;
-
+  const global = {admin:0, contabilidad:0, comunes:0};
   document.querySelectorAll('.subject-card').forEach(card => {
-    const name = card.dataset.nombre;
-    const sem = card.dataset.semester;
     if (card.dataset.homologada === 'true') return;
-
-    if (card.dataset.program === 'admin') {
-      const cred = Number(card.dataset.creditos);
-      adminPropios += cred;
-      totals[sem].admin += cred;
-    } else if (card.dataset.program === 'contabilidad') {
-      const cred = Number(card.dataset.creditos);
-      contPropios += cred;
-      totals[sem].contabilidad += cred;
-    } else if (card.dataset.program === 'comunes') {
-      const adminCred = adminByName[name] ? Number(adminByName[name].credits) : 0;
-      const contCred = contByName[name] ? Number(contByName[name].credits) : 0;
-      const unionCred = Number(card.dataset.creditos);
-      adminComunes += adminCred;
-      contComunes += contCred;
-      comunesUnion += unionCred;
-      totals[sem].admin += adminCred;
-      totals[sem].contabilidad += contCred;
-      totals[sem].comunes += unionCred;
-    }
+    const sem = card.dataset.semester;
+    if (!totals[sem]) totals[sem] = {admin:0, contabilidad:0, comunes:0};
+    const prog = card.dataset.program;
+    const cred = Number(card.dataset.creditos);
+    totals[sem][prog] += cred;
+    global[prog] += cred;
   });
 
   for (const sem in totals) {
@@ -230,23 +203,22 @@ function updateTotals() {
     }
   }
 
-  const adminTotal = adminPropios + adminComunes;
-  const contTotal = contPropios + contComunes;
-  const globalTotal = adminPropios + contPropios + comunesUnion;
+  const adminTotal = global.admin + global.comunes;
+  const contTotal = global.contabilidad + global.comunes;
+  const globalTotal = global.admin + global.contabilidad + global.comunes;
   const ahorro = adminRawTotal + contRawTotal - globalTotal;
-
   document.getElementById('admin-total-raw').textContent = adminRawTotal;
   document.getElementById('cont-total-raw').textContent = contRawTotal;
 
-  document.getElementById('admin-propios').textContent = adminPropios;
-  document.getElementById('admin-comunes').textContent = adminComunes;
+  document.getElementById('admin-propios').textContent = global.admin;
+  document.getElementById('admin-comunes').textContent = global.comunes;
   document.getElementById('admin-total').textContent = adminTotal;
 
-  document.getElementById('cont-propios').textContent = contPropios;
-  document.getElementById('cont-comunes').textContent = contComunes;
+  document.getElementById('cont-propios').textContent = global.contabilidad;
+  document.getElementById('cont-comunes').textContent = global.comunes;
   document.getElementById('cont-total').textContent = contTotal;
 
-  document.getElementById('total-comunes').textContent = comunesUnion;
+  document.getElementById('total-comunes').textContent = global.comunes;
   document.getElementById('total-global').textContent = globalTotal;
   document.getElementById('total-ahorro').textContent = ahorro;
 }

--- a/styles.css
+++ b/styles.css
@@ -202,9 +202,40 @@ button:hover {
   font-weight: bold;
 }
 
+.totals-container {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.totals-box {
+  flex: 1;
+  border: 1px solid var(--color-principal);
+  border-radius: 0.5rem;
+  background: #fff;
+  overflow: hidden;
+}
+
+.totals-box summary {
+  background-color: var(--color-principal);
+  color: #fff;
+  padding: 0.5rem;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.totals-content {
+  padding: 0.5rem 1rem;
+  text-align: center;
+  font-weight: bold;
+}
+
 @media (max-width: 768px) {
   .grid-container {
     grid-template-columns: 1fr;
+  }
+  .totals-container {
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
## Summary
- show static global totals and dynamic totals in separate columns
- remove the word "visible" from totals display
- make totals collapsible using `<details>`
- add CSS for layout and responsive behaviour

## Testing
- `python3 -m http.server 8000` *(served site locally)*
- `curl -s http://localhost:8000/index.html | head`

------
https://chatgpt.com/codex/tasks/task_e_68401ae172508326b85254f5e1661128