### PR TITLE
Update subject states and add progress meters

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,14 +52,14 @@
         <div class="totals-content progress-content">
           <h4>Administración</h4>
           <progress id="progress-admin" value="0" max="0"></progress>
-          <p>Completadas: <span id="admin-completed-count">0</span> (<span id="admin-completed-percent">0</span>%)</p>
-          <p>Homologadas: <span id="admin-homologated-count">0</span> (<span id="admin-homologated-percent">0</span>%)</p>
-          <p>Avance total: <span id="admin-progress-text">0</span>%</p>
+          <p>Completadas: <span id="admin-completed-count">0</span> materias (<span id="admin-completed-credits">0</span> créditos, <span id="admin-completed-percent">0</span>%)</p>
+          <p>Homologadas: <span id="admin-homologated-count">0</span> materias (<span id="admin-homologated-credits">0</span> créditos, <span id="admin-homologated-percent">0</span>%)</p>
+          <p>Avance total: <span id="admin-progress-credits">0</span> de <span id="admin-progress-total">0</span> créditos (<span id="admin-progress-text">0</span>%)</p>
           <h4>Contaduria</h4>
           <progress id="progress-cont" value="0" max="0"></progress>
-          <p>Completadas: <span id="cont-completed-count">0</span> (<span id="cont-completed-percent">0</span>%)</p>
-          <p>Homologadas: <span id="cont-homologated-count">0</span> (<span id="cont-homologated-percent">0</span>%)</p>
-          <p>Avance total: <span id="cont-progress-text">0</span>%</p>
+          <p>Completadas: <span id="cont-completed-count">0</span> materias (<span id="cont-completed-credits">0</span> créditos, <span id="cont-completed-percent">0</span>%)</p>
+          <p>Homologadas: <span id="cont-homologated-count">0</span> materias (<span id="cont-homologated-credits">0</span> créditos, <span id="cont-homologated-percent">0</span>%)</p>
+          <p>Avance total: <span id="cont-progress-credits">0</span> de <span id="cont-progress-total">0</span> créditos (<span id="cont-progress-text">0</span>%)</p>
         </div>
       </details>
       </div>

--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
       <p class="program-raw">Administración: <span id="admin-total-raw">0</span> créditos | Contabilidad: <span id="cont-total-raw">0</span> créditos</p>
     </div>
 
-    <div class="totals-container">
-      <details class="totals-box" id="static-box" open>
+      <div class="totals-container">
+      <details class="totals-box" id="static-box">
         <summary>Situación Global</summary>
         <div class="totals-content static-content">
           <p>Administración: 45 propios + 60 comunes = 105</p>
@@ -37,7 +37,7 @@
         </div>
       </details>
 
-      <details class="totals-box" id="dynamic-box" open>
+      <details class="totals-box" id="dynamic-box">
         <summary>Tus Cálculos</summary>
         <div class="totals-content global-totals">
           <p>Administración: <span id="admin-propios">0</span> propios + <span id="admin-comunes">0</span> comunes = <span id="admin-total">0</span></p>
@@ -47,12 +47,28 @@
           <p>Ahorro por doble titulación: <span id="total-ahorro">0</span> créditos</p>
         </div>
       </details>
-    </div>
-  
-    <div class="grid-container">
-      <div class="grid-header">Administración de Empresas</div>
-      <div class="grid-header">Materias Comunes</div>
-      <div class="grid-header">Contabilidad</div>
+      <details class="totals-box" id="progress-box">
+        <summary>Progreso</summary>
+        <div class="totals-content progress-content">
+          <h4>Administración</h4>
+          <progress id="progress-admin" value="0" max="0"></progress>
+          <p>Completadas: <span id="admin-completed-count">0</span> (<span id="admin-completed-percent">0</span>%)</p>
+          <p>Homologadas: <span id="admin-homologated-count">0</span> (<span id="admin-homologated-percent">0</span>%)</p>
+          <p>Avance total: <span id="admin-progress-text">0</span>%</p>
+          <h4>Contaduria</h4>
+          <progress id="progress-cont" value="0" max="0"></progress>
+          <p>Completadas: <span id="cont-completed-count">0</span> (<span id="cont-completed-percent">0</span>%)</p>
+          <p>Homologadas: <span id="cont-homologated-count">0</span> (<span id="cont-homologated-percent">0</span>%)</p>
+          <p>Avance total: <span id="cont-progress-text">0</span>%</p>
+        </div>
+      </details>
+      </div>
+
+      <div class="grid-container">
+      <div class="grid-title">MATERIAS</div>
+      <div class="grid-header">Administración</div>
+      <div class="grid-header">En Común</div>
+      <div class="grid-header">Contaduria</div>
 
     </div><!-- end grid-container -->
     <div id="subject-modal" class="modal hidden">

--- a/script.js
+++ b/script.js
@@ -344,19 +344,27 @@ function updateProgress() {
   document.getElementById('progress-admin').value = adminTotal;
   document.getElementById('progress-cont').value = contTotal;
   document.getElementById('admin-progress-text').textContent = adminPerc.toFixed(1);
+  document.getElementById('admin-progress-credits').textContent = adminTotal;
+  document.getElementById('admin-progress-total').textContent = adminProgramTotal;
   document.getElementById('cont-progress-text').textContent = contPerc.toFixed(1);
+  document.getElementById('cont-progress-credits').textContent = contTotal;
+  document.getElementById('cont-progress-total').textContent = contProgramTotal;
 
   document.getElementById('admin-completed-count').textContent = adminCompCount;
+  document.getElementById('admin-completed-credits').textContent = adminCompCred;
   document.getElementById('admin-completed-percent').textContent =
     adminProgramTotal ? (adminCompCred / adminProgramTotal * 100).toFixed(1) : 0;
   document.getElementById('admin-homologated-count').textContent = adminHomCount;
+  document.getElementById('admin-homologated-credits').textContent = adminHomCred;
   document.getElementById('admin-homologated-percent').textContent =
     adminProgramTotal ? (adminHomCred / adminProgramTotal * 100).toFixed(1) : 0;
 
   document.getElementById('cont-completed-count').textContent = contCompCount;
+  document.getElementById('cont-completed-credits').textContent = contCompCred;
   document.getElementById('cont-completed-percent').textContent =
     contProgramTotal ? (contCompCred / contProgramTotal * 100).toFixed(1) : 0;
   document.getElementById('cont-homologated-count').textContent = contHomCount;
+  document.getElementById('cont-homologated-credits').textContent = contHomCred;
   document.getElementById('cont-homologated-percent').textContent =
     contProgramTotal ? (contHomCred / contProgramTotal * 100).toFixed(1) : 0;
 }

--- a/script.js
+++ b/script.js
@@ -218,9 +218,9 @@ async function cargarMaterias() {
       contFiltered[sem] = rm ? list.filter(s => !rm.has(s.nombre)) : list.slice();
     }
 
-    const sumCredits = obj => Object.values(obj).flat().reduce((a, b) => a + Number(b.creditos), 0);
-    adminProgramTotal = sumCredits(adminFiltered) + sumCredits(commons);
-    contProgramTotal = sumCredits(contFiltered) + sumCredits(commons);
+    // Use the global totals from each program for progress calculations
+    adminProgramTotal = adminRawTotal;
+    contProgramTotal = contRawTotal;
     document.getElementById('progress-admin').max = adminProgramTotal;
     document.getElementById('progress-cont').max = contProgramTotal;
 

--- a/styles.css
+++ b/styles.css
@@ -243,7 +243,7 @@ button:hover {
 }
 
 .global-totals {
-  text-align: center;
+  text-align: left;
   margin: 1rem 0;
   font-weight: bold;
 }
@@ -273,7 +273,7 @@ button:hover {
 
 .totals-content {
   padding: 0.5rem 1rem;
-  text-align: center;
+  text-align: left;
   font-weight: bold;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -268,6 +268,7 @@ button:hover {
   padding: 0.5rem;
   cursor: pointer;
   font-weight: bold;
+  text-align: left;
 }
 
 .totals-content {

--- a/styles.css
+++ b/styles.css
@@ -99,6 +99,18 @@ body {
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
+.grid-title {
+  grid-column: 1 / -1;
+  text-align: center;
+  font-size: 2rem;
+  background-color: var(--color-secundario);
+  color: #fff;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
 /* Cada fila se define con .row, y cada columna con .column */
 .row {
   display: contents;
@@ -262,6 +274,16 @@ button:hover {
   padding: 0.5rem 1rem;
   text-align: center;
   font-weight: bold;
+}
+
+progress {
+  width: 100%;
+  height: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.progress-content h4 {
+  margin: 0.5rem 0;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- prevent cards from being both homologated and completed
- collapse detail sections by default
- add a progress summary with `<progress>` bars
- rename column headers and add `MATERIAS` row title
- update styles for new elements

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6840325c824483268b05db54bc9bd5f7