### PR TITLE
Improve summary layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,22 +29,22 @@
       <section class="dashboard-card" id="static-box">
         <h3>Situación Global</h3>
         <div class="dashboard-content static-content">
-          <p>Administración: 45 propios + 60 comunes = 105</p>
-          <p>Contabilidad: 50 propios + 57 comunes = 107</p>
-          <p>Créditos Comunes: 60</p>
-          <p>Total Doble Titulación: 155</p>
-          <p>Ahorro por doble titulación: 57 créditos</p>
+          <div class="dashboard-row"><span class="label">Administración:</span><span>45 propios + 60 comunes = 105</span></div>
+          <div class="dashboard-row"><span class="label">Contabilidad:</span><span>50 propios + 57 comunes = 107</span></div>
+          <div class="dashboard-row"><span class="label">Créditos Comunes:</span><span>60</span></div>
+          <div class="dashboard-row"><span class="label">Total Doble Titulación:</span><span>155</span></div>
+          <div class="dashboard-row"><span class="label">Ahorro por doble titulación:</span><span>57 créditos</span></div>
         </div>
       </section>
 
       <section class="dashboard-card" id="dynamic-box">
         <h3>Tus Cálculos</h3>
         <div class="dashboard-content global-totals">
-          <p>Administración: <span id="admin-propios">0</span> propios + <span id="admin-comunes">0</span> comunes = <span id="admin-total">0</span></p>
-          <p>Contabilidad: <span id="cont-propios">0</span> propios + <span id="cont-comunes">0</span> comunes = <span id="cont-total">0</span></p>
-          <p>Créditos Comunes: <span id="total-comunes">0</span></p>
-          <p>Total Doble Titulación: <span id="total-global">0</span></p>
-          <p>Ahorro por doble titulación: <span id="total-ahorro">0</span> créditos</p>
+          <div class="dashboard-row"><span class="label">Administración:</span><span><span id="admin-propios">0</span> propios + <span id="admin-comunes">0</span> comunes = <span id="admin-total">0</span></span></div>
+          <div class="dashboard-row"><span class="label">Contabilidad:</span><span><span id="cont-propios">0</span> propios + <span id="cont-comunes">0</span> comunes = <span id="cont-total">0</span></span></div>
+          <div class="dashboard-row"><span class="label">Créditos Comunes:</span><span><span id="total-comunes">0</span></span></div>
+          <div class="dashboard-row"><span class="label">Total Doble Titulación:</span><span><span id="total-global">0</span></span></div>
+          <div class="dashboard-row"><span class="label">Ahorro por doble titulación:</span><span><span id="total-ahorro">0</span> créditos</span></div>
         </div>
       </section>
       <section class="dashboard-card" id="progress-box">
@@ -52,14 +52,14 @@
         <div class="dashboard-content progress-content">
           <h4>Administración</h4>
           <progress id="progress-admin" value="0" max="0"></progress>
-          <p>Completadas: <span id="admin-completed-count">0</span> materias (<span id="admin-completed-credits">0</span> créditos, <span id="admin-completed-percent">0</span>%)</p>
-          <p>Homologadas: <span id="admin-homologated-count">0</span> materias (<span id="admin-homologated-credits">0</span> créditos, <span id="admin-homologated-percent">0</span>%)</p>
-          <p>Avance total: <span id="admin-progress-credits">0</span> de <span id="admin-progress-total">0</span> créditos (<span id="admin-progress-text">0</span>%)</p>
+          <div class="dashboard-row"><span class="label">Completadas:</span><span><span id="admin-completed-count">0</span> materias (<span id="admin-completed-credits">0</span> créditos, <span id="admin-completed-percent">0</span>%)</span></div>
+          <div class="dashboard-row"><span class="label">Homologadas:</span><span><span id="admin-homologated-count">0</span> materias (<span id="admin-homologated-credits">0</span> créditos, <span id="admin-homologated-percent">0</span>%)</span></div>
+          <div class="dashboard-row"><span class="label">Avance total:</span><span><span id="admin-progress-credits">0</span> de <span id="admin-progress-total">0</span> créditos (<span id="admin-progress-text">0</span>%)</span></div>
           <h4>Contaduria</h4>
           <progress id="progress-cont" value="0" max="0"></progress>
-          <p>Completadas: <span id="cont-completed-count">0</span> materias (<span id="cont-completed-credits">0</span> créditos, <span id="cont-completed-percent">0</span>%)</p>
-          <p>Homologadas: <span id="cont-homologated-count">0</span> materias (<span id="cont-homologated-credits">0</span> créditos, <span id="cont-homologated-percent">0</span>%)</p>
-          <p>Avance total: <span id="cont-progress-credits">0</span> de <span id="cont-progress-total">0</span> créditos (<span id="cont-progress-text">0</span>%)</p>
+          <div class="dashboard-row"><span class="label">Completadas:</span><span><span id="cont-completed-count">0</span> materias (<span id="cont-completed-credits">0</span> créditos, <span id="cont-completed-percent">0</span>%)</span></div>
+          <div class="dashboard-row"><span class="label">Homologadas:</span><span><span id="cont-homologated-count">0</span> materias (<span id="cont-homologated-credits">0</span> créditos, <span id="cont-homologated-percent">0</span>%)</span></div>
+          <div class="dashboard-row"><span class="label">Avance total:</span><span><span id="cont-progress-credits">0</span> de <span id="cont-progress-total">0</span> créditos (<span id="cont-progress-text">0</span>%)</span></div>
         </div>
       </section>
       </div>

--- a/index.html
+++ b/index.html
@@ -25,31 +25,31 @@
       <p class="program-raw">Administración: <span id="admin-total-raw">0</span> créditos | Contabilidad: <span id="cont-total-raw">0</span> créditos</p>
     </div>
 
-      <div class="totals-container">
-      <details class="totals-box" id="static-box">
-        <summary>Situación Global</summary>
-        <div class="totals-content static-content">
+      <div class="dashboard-grid">
+      <section class="dashboard-card" id="static-box">
+        <h3>Situación Global</h3>
+        <div class="dashboard-content static-content">
           <p>Administración: 45 propios + 60 comunes = 105</p>
           <p>Contabilidad: 50 propios + 57 comunes = 107</p>
           <p>Créditos Comunes: 60</p>
           <p>Total Doble Titulación: 155</p>
           <p>Ahorro por doble titulación: 57 créditos</p>
         </div>
-      </details>
+      </section>
 
-      <details class="totals-box" id="dynamic-box">
-        <summary>Tus Cálculos</summary>
-        <div class="totals-content global-totals">
+      <section class="dashboard-card" id="dynamic-box">
+        <h3>Tus Cálculos</h3>
+        <div class="dashboard-content global-totals">
           <p>Administración: <span id="admin-propios">0</span> propios + <span id="admin-comunes">0</span> comunes = <span id="admin-total">0</span></p>
           <p>Contabilidad: <span id="cont-propios">0</span> propios + <span id="cont-comunes">0</span> comunes = <span id="cont-total">0</span></p>
           <p>Créditos Comunes: <span id="total-comunes">0</span></p>
           <p>Total Doble Titulación: <span id="total-global">0</span></p>
           <p>Ahorro por doble titulación: <span id="total-ahorro">0</span> créditos</p>
         </div>
-      </details>
-      <details class="totals-box" id="progress-box">
-        <summary>Progreso</summary>
-        <div class="totals-content progress-content">
+      </section>
+      <section class="dashboard-card" id="progress-box">
+        <h3>Progreso</h3>
+        <div class="dashboard-content progress-content">
           <h4>Administración</h4>
           <progress id="progress-admin" value="0" max="0"></progress>
           <p>Completadas: <span id="admin-completed-count">0</span> materias (<span id="admin-completed-credits">0</span> créditos, <span id="admin-completed-percent">0</span>%)</p>
@@ -61,7 +61,7 @@
           <p>Homologadas: <span id="cont-homologated-count">0</span> materias (<span id="cont-homologated-credits">0</span> créditos, <span id="cont-homologated-percent">0</span>%)</p>
           <p>Avance total: <span id="cont-progress-credits">0</span> de <span id="cont-progress-total">0</span> créditos (<span id="cont-progress-text">0</span>%)</p>
         </div>
-      </details>
+      </section>
       </div>
 
       <div class="grid-container">

--- a/styles.css
+++ b/styles.css
@@ -277,6 +277,24 @@ button:hover {
   font-weight: bold;
 }
 
+.dashboard-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.25rem 0.5rem;
+}
+
+.dashboard-content .dashboard-row:nth-child(odd) {
+  background-color: #f0f0f0;
+}
+
+.dashboard-content .dashboard-row:nth-child(even) {
+  background-color: #f7f3e5;
+}
+
+.dashboard-row .label {
+  font-weight: 900;
+}
+
 progress {
   width: 100%;
   height: 1rem;

--- a/styles.css
+++ b/styles.css
@@ -248,13 +248,13 @@ button:hover {
   font-weight: bold;
 }
 
-.totals-container {
+.dashboard-grid {
   display: flex;
   gap: 1rem;
   margin: 1rem 0;
 }
 
-.totals-box {
+.dashboard-card {
   flex: 1;
   border: 1px solid var(--color-principal);
   border-radius: 0.5rem;
@@ -262,16 +262,16 @@ button:hover {
   overflow: hidden;
 }
 
-.totals-box summary {
+.dashboard-card h3 {
   background-color: var(--color-principal);
   color: #fff;
   padding: 0.5rem;
-  cursor: pointer;
+  margin: 0;
+  text-align: center;
   font-weight: bold;
-  text-align: left;
 }
 
-.totals-content {
+.dashboard-content {
   padding: 0.5rem 1rem;
   text-align: left;
   font-weight: bold;
@@ -291,7 +291,7 @@ progress {
   .grid-container {
     grid-template-columns: 1fr;
   }
-  .totals-container {
+  .dashboard-grid {
     flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- switch from collapsible summaries to dashboard sections
- add new dashboard styles in CSS

## Testing
- `python3 -m py_compile update_codes.py`

------
https://chatgpt.com/codex/tasks/task_e_68404aafde588326a49c5f615d6bc455