### PR TITLE
Handle multiple requisites

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     <div id="subject-modal" class="modal hidden">
       <div class="modal-box">
         <h3 id="modal-title"></h3>
-        <button id="btn-prereq">Consultar prerequisito</button>
+        <button id="btn-prereq">Consultar requisitos</button>
         <button id="btn-homologada">Marcar como homologada</button>
         <button id="btn-completada">Marcar como completada</button>
         <select id="move-semester"></select>

--- a/styles.css
+++ b/styles.css
@@ -199,6 +199,18 @@ button:hover {
   display: none;
 }
 
+.highlight {
+  outline: 3px solid var(--color-acento);
+}
+
+.req-met {
+  color: green;
+}
+
+.req-pend {
+  color: gray;
+}
+
 .modal {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- support multiple prereqs and coreqs on subject cards
- display them in the modal with status icons and links
- show highlight when selecting a requisite
- track locking based on all requirements

## Testing
- `node -e "require('./script.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68461d24b6ac8326b6e392b10b9892d3